### PR TITLE
feat: Add class to Emoji-widget, to make it targetable for css select…

### DIFF
--- a/tag.ts
+++ b/tag.ts
@@ -19,6 +19,7 @@ import { syntaxTree } from "@codemirror/language";
 export class EmojiWidget extends WidgetType {
     toDOM(view: EditorView): HTMLElement {
         const span = document.createElement("span");
+		span.classList.add("aosr-emoji-widget");
         span.innerText = "🏷";
         return span;
     }


### PR DESCRIPTION
Now if users want to apply a CSS snippet to emoji-widgets, they can easily do that with `span.aosr-emoji-widget` css selector and for example hide the emoji completely. 