### PR TITLE
feat(multi-line): Allow multi-lines in Range-cards include empty lines.

### DIFF
--- a/patternLine.tsx
+++ b/patternLine.tsx
@@ -202,7 +202,7 @@ export class MultiLineParser implements PatternParser {
 	Parse(card: Card): Pattern[] {
 		let sepEscaped = escapeRegExp(GlobalSettings.MultiLineDelimeter);
 		let reg = new RegExp(
-			`^((?:(?!(?:${sepEscaped}) ?).+\\n)+)(?:${sepEscaped}) *( #.+)?\\n((?:.+\\n?)+)$`,
+			`^((?:(?!(?:${sepEscaped}) ?).*\n)+)(?:${sepEscaped}) *( #.+)?\n((?:.*\n?)+)$`,
 			cardParserRegFlags);
 		// 捕获不包含? 开头的连续行 然后捕获标签 然后捕获剩余行
 		let results: Pattern[] = []


### PR DESCRIPTION
Before:
Range card didn't allow multiline patterns to include empty lines
Example1:
```
#Q
line1

line2
?
line3

line4
#/Q
```
The parsed card will be   `line2 ? line3`  while `line1` and `line4` are cut out.

Now all lines are included and the card will look like exactly as it is written. 
I checked that this change interacts gracefully with sub-cards splitters. 
As they have priority over multi-lining. 




